### PR TITLE
pull request for download of attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ env.sh
 discourse/
 *.gem
 *.rbc
+*.yaml
 /.config
 /coverage/
 /InstalledFiles
@@ -34,3 +35,5 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+/nbproject/private/
+/topics/

--- a/env.sh.template
+++ b/env.sh.template
@@ -1,4 +1,5 @@
 # USAGE
+# any special characters in GOOGLE_PASSWORD should be escaped with \
 # $ source ./env.sh
 
 export GOOGLE_USER=""

--- a/gg.to_d.rb
+++ b/gg.to_d.rb
@@ -32,7 +32,8 @@ class GoogleGroupToDiscourse
           application/x-zip-compressed , application/zip , application/x-rar-compressed , application/msword , application/excel , 
           application/vnd.ms-excel , application/x-excel , application/x-msexcel , text/plain , image/tiff , image/x-tiff, image/png , image/gif , 
           audio/x-wav , audio/mpeg , application/pdf , application/vnd.openxmlformats-officedocument.spreadsheetml.sheet , 
-          application/vnd.openxmlformats-officedocument.wordprocessingml.document , video/mp4 , audio/mp4 , audio/ogg, video/ogg , video/mpeg'
+          application/vnd.openxmlformats-officedocument.wordprocessingml.document , video/mp4 , audio/mp4 , audio/ogg, video/ogg , video/mpeg ,
+          image/bmp'
         profile['pdfjs.disabled'] = true
 
     # initialize a driver to look up DOM information and another for scraping raw email information

--- a/gg.to_d.rb
+++ b/gg.to_d.rb
@@ -4,6 +4,8 @@ require 'nokogiri'
 require 'cgi'
 require 'json'
 require 'discourse_api'
+require 'yaml'
+
 
 
 class GoogleGroupToDiscourse
@@ -82,7 +84,7 @@ class GoogleGroupToDiscourse
   def get_messages (topic)
     topic[:messages] =[] # messages will be appended to this as an array of hashes
     @driver.navigate.to topic[:url]
-    sleep (5) #wait for it to load
+    sleep (3) #wait for it to load
     # expand all the message_snippets
     minimized_messages = @driver.find_elements(:xpath, "//span[contains(@id, 'message_snippet_')]")
     minimized_messages.each { |link| link.click; sleep (0.2)}
@@ -124,6 +126,23 @@ class GoogleGroupToDiscourse
     end
     puts "All topics saved to ./topics/ directory in JSON format"
   end
+
+  def save_all_topics_yaml
+    topics = get_topics
+    File.open("all_topics.yaml", "w") do |file|
+    topics.each_with_index do |index|
+      file.puts YAML::dump(index)
+      file.puts ""
+    end
+  end
+
+  def load_all_topics_yaml
+    topics = []
+    $/="\n\n"
+    File.open("all_topics.yaml", "r").each do |object|
+      topics << YAML::load(object)
+    end
+  end 
 
   def save_topic_json(topic)
     topic_json = get_messages(topic).to_json

--- a/gg.to_d.rb
+++ b/gg.to_d.rb
@@ -29,9 +29,10 @@ class GoogleGroupToDiscourse
         profile['browser.download.manager.showWhenStarting'] = false
         profile['browser.download.dir'] = '/tmp/scraper-saves'
         profile['browser.helperApps.neverAsk.saveToDisk'] = 'application/octet-stream , audio/mpeg3 , audio/x-mpeg-3 , image/jpeg , application/x-compressed , 
-          application/x-zip-compressed , application/zip , application/x-rar-compressed , application/msword , application/excel ,
+          application/x-zip-compressed , application/zip , application/x-rar-compressed , application/msword , application/excel , 
           application/vnd.ms-excel , application/x-excel , application/x-msexcel , text/plain , image/tiff , image/x-tiff, image/png , image/gif , 
-          audio/x-wav , audio/mpeg , application/pdf'
+          audio/x-wav , audio/mpeg , application/pdf , application/vnd.openxmlformats-officedocument.spreadsheetml.sheet , 
+          application/vnd.openxmlformats-officedocument.wordprocessingml.document , video/mp4 , audio/mp4 , audio/ogg, video/ogg , video/mpeg'
         profile['pdfjs.disabled'] = true
 
     # initialize a driver to look up DOM information and another for scraping raw email information
@@ -119,7 +120,7 @@ class GoogleGroupToDiscourse
       if !attachment.nil? and !attachment.attribute(:href).nil? 
         driver.navigate().to(attachment.attribute(:href))
         #some attachments are big, wait for download
-        sleep(10)
+        sleep(15)
         found_attachments = found_attachments + 1
       end
     end

--- a/gg.to_d.rb
+++ b/gg.to_d.rb
@@ -28,9 +28,11 @@ class GoogleGroupToDiscourse
         profile['browser.download.folderList'] = 2
         profile['browser.download.manager.showWhenStarting'] = false
         profile['browser.download.dir'] = '/tmp/scraper-saves'
-        profile['browser.helperApps.neverAsk.saveToDisk'] = 'application/octet-stream , audio/mpeg3 , audio/x-mpeg-3 , image/jpeg application/x-compressed, 
+        profile['browser.helperApps.neverAsk.saveToDisk'] = 'application/octet-stream , audio/mpeg3 , audio/x-mpeg-3 , image/jpeg , application/x-compressed , 
           application/x-zip-compressed , application/zip , application/x-rar-compressed , application/msword , application/excel ,
-          application/vnd.ms-excel , application/x-excel , application/x-msexcel , text/plain , image/tiff , image/x-tiff'
+          application/vnd.ms-excel , application/x-excel , application/x-msexcel , text/plain , image/tiff , image/x-tiff, image/png , image/gif , 
+          audio/x-wav , audio/mpeg , application/pdf'
+        profile['pdfjs.disabled'] = true
 
     # initialize a driver to look up DOM information and another for scraping raw email information
   	@driver = Selenium::WebDriver.for :firefox, :profile => profile
@@ -115,14 +117,15 @@ class GoogleGroupToDiscourse
     all_attachments = @driver.find_elements(:xpath, "//a[contains(@href, 'group/chimeresgr/attach/')]").reject { |link| link['href'].include? 'view=1' } 
     all_attachments.each do |attachment|
       if !attachment.nil? and !attachment.attribute(:href).nil? 
-        puts  "#{attachment.attribute(:href)}"
         driver.navigate().to(attachment.attribute(:href))
+        #some attachments are big, wait for download
+        sleep(10)
         found_attachments = found_attachments + 1
       end
     end
     return found_attachments
   end
-    
+  
   def scrape_the_lot
     topics = get_topics
     topics.each do |topic|

--- a/gg.to_d.rb
+++ b/gg.to_d.rb
@@ -130,9 +130,10 @@ class GoogleGroupToDiscourse
   def save_all_topics_yaml
     topics = get_topics
     File.open("all_topics.yaml", "w") do |file|
-    topics.each_with_index do |index|
-      file.puts YAML::dump(index)
-      file.puts ""
+      topics.each_with_index do |index|
+        file.puts YAML::dump(index)
+        file.puts ""
+      end
     end
   end
 
@@ -142,6 +143,7 @@ class GoogleGroupToDiscourse
     File.open("all_topics.yaml", "r").each do |object|
       topics << YAML::load(object)
     end
+    puts topics
   end 
 
   def save_topic_json(topic)

--- a/gg.to_d.rb
+++ b/gg.to_d.rb
@@ -83,9 +83,9 @@ class GoogleGroupToDiscourse
     all_messages = @driver.find_elements(:xpath, "//div[contains(@id, 'b_action_')]")
     puts "#{all_messages.count} messages in this thread"
     # iterate through messages
-    sender = @driver.find_elements(:class, 'GFP-UI5CA1B')
-    date = @driver.find_elements(:class, 'GFP-UI5CDKB')
-    body = @driver.find_elements(:class, 'GFP-UI5CCKB').reject! { |c| c.text=="" } #reject blank ones
+    sender = @driver.find_elements(:class, 'H1SYRSB-P-a')
+    date = @driver.find_elements(:class, 'H1SYRSB-wb-Q')
+    body = @driver.find_elements(:class, 'H1SYRSB-wb-P').reject! { |c| c.text=="" } #reject blank ones
     all_messages.each_with_index do |message, index|
       topic[:messages] << { sender: sender[index].text, date: date[index].attribute(:title), body: body[index].text }
     end
@@ -96,11 +96,12 @@ class GoogleGroupToDiscourse
     topics = get_topics
     topics.each do |topic|
       messages = get_messages( topic )
-      # this would be where to insert any cruft-removal code
-      send_to_discourse( messages )
-      puts "All topics migrated to Discourse"
-      close_browsers
     end
+    # this would be where to insert any cruft-removal code
+    send_to_discourse( messages )
+    puts "All topics migrated to Discourse"
+    close_browsers
+  end
 
   def save_all_topics_json(start_at_topic_number=0)
     topics = get_topics

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,7 @@
+include.path=${php.global.include.path}
+php.version=PHP_54
+source.encoding=UTF-8
+src.dir=.
+tags.asp=false
+tags.short=false
+web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.php.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/php-project/1">
+            <name>google_group.to_discourse</name>
+        </data>
+    </configuration>
+</project>

--- a/testit.rb
+++ b/testit.rb
@@ -1,0 +1,4 @@
+load 'gg.to_d.rb'
+my_scraper = GoogleGroupToDiscourse.new
+my_scraper.load_all_topics_yaml
+


### PR DESCRIPTION
This is my 1st pull request so be gentle :) I too am not a Ruby programmer, so all stuff were done on instinct and Googling! Many thanks to @pacharanero for his original work!
Added support for 
  downloading attachments (create profile for selenium firefox where common mime-types are automatically downloaded and no prompts and relevant code)
  saving and loading scrapped topics in YAML format, so that you don't have to restart the process everytime if you want to test stuff (could select a subset of topics i.e. create a small all_topics.yaml and load it). 
  changed the css classes for the scraped items (although I think Google changes them all the time or depends on user account that logins)
